### PR TITLE
Fix signWithAlgorithm method on RSA Module

### DIFF
--- a/android/src/main/java/com/RNRSA/RNRSAModule.java
+++ b/android/src/main/java/com/RNRSA/RNRSAModule.java
@@ -157,12 +157,13 @@ public class RNRSAModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void signWithAlgorithm(final String message, final String keyTag, final String algorithm, final Promise promise) {
+  public void signWithAlgorithm(final String message, final String privateKeyString, final String algorithm, final Promise promise) {
     AsyncTask.execute(new Runnable() {
       @Override
       public void run() {
         try {
-          RSA rsa = new RSA(keyTag);
+          RSA rsa = new RSA();
+          rsa.setPrivateKey(privateKeyString);
           String signature = rsa.sign(message, algorithm);
           promise.resolve(signature);
 

--- a/ios/RNRSA.m
+++ b/ios/RNRSA.m
@@ -81,6 +81,15 @@ RCT_EXPORT_METHOD(decrypt64:(NSString *)encodedMessage withKey:(NSString *)key r
     });
 }
 
+RCT_EXPORT_METHOD(signWithAlgorithm:(NSString *)message withKey:(NSString *)key withAlgorithm:(NSString *)algorithm resolve:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        RSANative *rsa = [[RSANative alloc] init];
+        rsa.privateKey = key;
+        NSString *signature = [rsa sign:message withAlgorithm: algorithm withEncodeOption: NSDataBase64Encoding64CharacterLineLength];
+        resolve(signature);
+    });
+}
 
 RCT_EXPORT_METHOD(sign:(NSString *)message withKey:(NSString *)key resolve:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {


### PR DESCRIPTION
The method signWithAlgorithm was missing on IOS implementation of RSA object and the Android implementation was not working properly with a string key (pem)